### PR TITLE
Videos: Add Collection of Awesome Haskell Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A collection of resources which were useful to Tweagers for learning Haskell and
 ### Videos
 
 - [C9 Lectures: Erik Meijer - Functional Programming Fundamentals](https://docs.microsoft.com/en-us/shows/c9-lectures-erik-meijer-functional-programming-fundamentals/)
+- [Collection of Awesome Haskell Videos](https://andys8.github.io/awesome-haskell-videos)
 
 ## Specific topics
 


### PR DESCRIPTION
Hey, in case you think this makes sense, I've a list of "Awesome Haskell Videos" and added it to the Videos category. At the same time I cross linked the project to the `awesome-learning-haskell` list (https://github.com/andys8/awesome-haskell-videos/commit/6be4a671f6c6b631bedb28a20e32b9e6ae2d32c2). Thanks for your effort and creating a great collection :)